### PR TITLE
Fix loading scenes from asset bundles

### DIFF
--- a/Runtime/Core/LayerKernel.cs
+++ b/Runtime/Core/LayerKernel.cs
@@ -201,28 +201,7 @@ namespace Pixeye.Actors
       UnmanagedMemory.Cleanup();
     }
 
-    internal static string NameFromIndex(int BuildIndex)
-    {
-      var path  = SceneUtility.GetScenePathByBuildIndex(BuildIndex);
-      var slash = path.LastIndexOf('/');
-      var name  = path.Substring(slash + 1);
-      var dot   = name.LastIndexOf('.');
-      return name.Substring(0, dot);
-    }
-
-    internal static int SceneIndexFromName(string sceneName)
-    {
-      for (var i = 0; i < SceneManager.sceneCountInBuildSettings; i++)
-      {
-        var testedScreen = NameFromIndex(i);
-        if (testedScreen == sceneName)
-          return i;
-      }
-
-      return -1;
-    }
-
-    public void Tick(float dt)
+        public void Tick(float dt)
     {
       HandleLoadingProgress();
     }

--- a/Runtime/Core/SceneMain.cs
+++ b/Runtime/Core/SceneMain.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using UnityEngine;
 using UnityEngine.SceneManagement;
@@ -14,25 +14,25 @@ namespace Pixeye.Actors
     public static void ChangeTo(int buildIndex)
     {
       NextActiveSceneName = SceneManager.GetSceneByBuildIndex(buildIndex).name;
-      ChangeOp(buildIndex);
+      ChangeOp(NextActiveSceneName);
     }
 
     public static void ChangeTo(string sceneName)
     {
       NextActiveSceneName = sceneName;
-      ChangeOp(LayerKernel.SceneIndexFromName(sceneName));
+      ChangeOp(sceneName);
     }
 
-    static void ChangeOp(int buildIndex)
+    static void ChangeOp(string sceneName)
     {
-      var nextIndex = buildIndex;
+      var nextScene = sceneName;
 
-      LayerKernel.Initialized[buildIndex] = false;
+      LayerKernel.Initialized[SceneSub.GetLayerIndex(sceneName)] = false;
       Closed();
       Layer.ActiveLayer.Release();
       LayerKernel.LoadJobs.Add(SceneManager.UnloadSceneAsync(Layer.ActiveLayer.Scene));
       LayerKernel.LoadJobs.Add(Resources.UnloadUnusedAssets());
-      LayerKernel.LoadJobs.Add(SceneManager.LoadSceneAsync(buildIndex, LoadSceneMode.Additive));
+      LayerKernel.LoadJobs.Add(SceneManager.LoadSceneAsync(sceneName, LoadSceneMode.Additive));
       Layer.ActiveLayer = null;
       LayerKernel.RunUnscaled(CoChangeOP());
       
@@ -40,7 +40,7 @@ namespace Pixeye.Actors
       {
         while (LayerKernel.LoadJobs.Count > 0)
           yield return 0;
-        NextActiveSceneName = SceneManager.GetSceneByBuildIndex(nextIndex).name;
+        NextActiveSceneName = nextScene;
       }
     }
   }

--- a/Runtime/Core/SceneSub.cs
+++ b/Runtime/Core/SceneSub.cs
@@ -1,5 +1,6 @@
-﻿using System;
+using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Diagnostics;
 using UnityEngine;
 using UnityEngine.SceneManagement;
@@ -16,67 +17,85 @@ namespace Pixeye.Actors
       NotAdded
     }
 
-    static State CheckSceneState(int buildIndex)
-    {
-      if (buildIndex == -1) return State.InvalidIndex;
+        private static readonly Dictionary<string, int> loadedScenes = new Dictionary<string, int>();
+        private static readonly Stack<int> freeIndexes = new Stack<int>();
+        private static int layerСounter;
 
-      for (int i = 0; i < SceneManager.sceneCount; i++)
-      {
-        var scn = SceneManager.GetSceneAt(i);
-        if (scn.buildIndex == buildIndex) return State.AlreadyAdded;
-      }
+        static State CheckSceneState(string sceneName)
+        {
+            if (loadedScenes.ContainsKey(sceneName)) { return State.AlreadyAdded; }
+            else { return State.NotAdded; }
+        }
 
-      return State.NotAdded;
+        public static void Add(int buildIndex)
+        {
+            var sceneName = NameFromBuildIndex(buildIndex);
+            Add(sceneName);
+        }
+
+        public static void Add(string sceneName)
+        {
+            var name = System.IO.Path.GetFileNameWithoutExtension(sceneName);
+            var state = CheckSceneState(name);
+            if (state == State.AlreadyAdded) return;
+
+            var layerIndex = GetLayerIndex(name);
+            LayerKernel.Initialized[layerIndex] = false;
+            LayerKernel.LoadJobs.Add(SceneManager.LoadSceneAsync(sceneName, LoadSceneMode.Additive));
+        }
+
+        public static void Remove(int buildIndex)
+        {
+            DebugScene(buildIndex);
+            var sceneName = NameFromBuildIndex(buildIndex);
+            Remove(sceneName);
+        }
+
+        public static void Remove(string sceneName)
+        {
+            var state = CheckSceneState(sceneName);
+            if (state == State.InvalidIndex || state == State.NotAdded) return;
+            RemoveOp(sceneName);
+        }
+
+        static void RemoveOp(string sceneName)
+        {
+          var layerIndex = GetLayerIndex(sceneName);
+          if (LayerKernel.Layers[layerIndex] != null) // check if this scene is a part of Actors Layers.
+              LayerKernel.Layers[layerIndex].Release();
+          LayerKernel.LoadJobs.Add(SceneManager.UnloadSceneAsync(sceneName));
+          LayerKernel.LoadJobs.Add(Resources.UnloadUnusedAssets());
+          loadedScenes.Remove(sceneName);
+          freeIndexes.Push(layerIndex);
+        }
+    
+        internal static int GetLayerIndex(string sceneName) {
+            if (!loadedScenes.ContainsKey(sceneName))
+            {
+              loadedScenes.Add(sceneName, (freeIndexes.Count > 0) ? freeIndexes.Pop() : layerСounter++);
+            }
+            return loadedScenes[sceneName];
+        }
+
+        public static string NameFromBuildIndex(int buildIndex)
+        {
+            var path = SceneUtility.GetScenePathByBuildIndex(buildIndex);
+            if (String.IsNullOrEmpty(path)) { 
+                DebugScene(buildIndex);
+                //Return the index of the current scene
+                return SceneManager.GetActiveScene().name; 
+            }
+            return System.IO.Path.GetFileNameWithoutExtension(path);
+        }
+
+        [Conditional("ACTORS_DEBUG")]
+        static void DebugScene(int buildIndex)
+        {
+            if (buildIndex == -1)
+            {
+                Debug.Log($"There is no scene with Build Index {buildIndex}.");
+                throw new Exception();
+            }
+        }
     }
-
-    public static void Add(int buildIndex)
-    {
-      var state = CheckSceneState(buildIndex);
-      if (state == State.AlreadyAdded) return;
-
-      LayerKernel.Initialized[buildIndex] = false;
-      LayerKernel.LoadJobs.Add(SceneManager.LoadSceneAsync(buildIndex, LoadSceneMode.Additive));
-    }
-
-    public static void Add(string sceneName)
-    {
-      var buildIndex = LayerKernel.SceneIndexFromName(sceneName);
-      DebugScene(buildIndex);
-      Add(buildIndex);
-    }
-
-    public static void Remove(int buildIndex)
-    {
-      var state = CheckSceneState(buildIndex);
-      if (state == State.InvalidIndex || state == State.NotAdded) return;
-      RemoveOp(buildIndex);
-    }
-
-    public static void Remove(string sceneName)
-    {
-      var buildIndex = SceneManager.GetSceneByName(sceneName).buildIndex;
-      var state      = CheckSceneState(buildIndex);
-      if (state == State.InvalidIndex || state == State.NotAdded) return;
-
-      RemoveOp(buildIndex);
-    }
-
-    static void RemoveOp(int buildIndex)
-    {
-      if (LayerKernel.Layers[buildIndex] != null) // check if this scene is a part of Actors Layers.
-        LayerKernel.Layers[buildIndex].Release();
-      LayerKernel.LoadJobs.Add(SceneManager.UnloadSceneAsync(buildIndex));
-      LayerKernel.LoadJobs.Add(Resources.UnloadUnusedAssets());
-    }
-
-    [Conditional("ACTORS_DEBUG")]
-    static void DebugScene(int buildIndex)
-    {
-      if (buildIndex == -1)
-      {
-        Debug.Log($"There is no scene with Build Index {buildIndex}.");
-        throw new Exception();
-      }
-    }
-  }
 }

--- a/Runtime/LibMono/MonoCached.cs
+++ b/Runtime/LibMono/MonoCached.cs
@@ -20,16 +20,16 @@ namespace Pixeye.Actors
 
     protected virtual void Start()
     {
-      if (!LayerKernel.InstanceInternal || !LayerKernel.Initialized[gameObject.scene.buildIndex]) return;
+      if (!LayerKernel.InstanceInternal || !LayerKernel.Initialized[SceneSub.GetLayerIndex(gameObject.scene.name)]) return;
       if (Layer != null) return;
       
-      Layer = LayerKernel.Layers[gameObject.scene.buildIndex];
+      Layer = LayerKernel.Layers[SceneSub.GetLayerIndex(gameObject.scene.name)];
       Setup();
     }
 
     void OnEnable()
     {
-      if (!LayerKernel.InstanceInternal || !LayerKernel.Initialized[gameObject.scene.buildIndex]) return;
+      if (!LayerKernel.InstanceInternal || !LayerKernel.Initialized[SceneSub.GetLayerIndex(gameObject.scene.name)]) return;
       HandleEnable();
     }
 


### PR DESCRIPTION
warning: this implementation does not take into account that different asset bundles may have scenes with the same names. If you save the path to the scene in the dictionary instead of the scene name, this problem is resolved.